### PR TITLE
Update Media.php

### DIFF
--- a/src/services/Media.php
+++ b/src/services/Media.php
@@ -117,7 +117,7 @@ class Media extends Component
 
         foreach ($data['data'] as $media) {
             $model = new MediaModel([
-                'caption' => $media['caption'],
+                'caption' => $media['caption'] ?? '',
                 'id' => $media['id'],
                 'mediaType' => $media['media_type'],
                 'mediaUrl' => $media['media_url'],


### PR DESCRIPTION
Seems the media arrays from the API are missing the 'caption' key sometimes, and it throws a notice, therefore a 500 on a production environment. This PR fixes it